### PR TITLE
Compatibility with latest Impyla

### DIFF
--- a/impala_load_test.py
+++ b/impala_load_test.py
@@ -10,7 +10,6 @@ import sys
 import socket
 
 from impala.dbapi import connect
-# from impala.rpc import TTransportException
 import tornado.ioloop
 try:
     import simplejson as json
@@ -20,14 +19,11 @@ import tornado.web
 
 from stats import get_stats_tables, print_stats
 
-
-
 # Date Format
 DATE_FORMAT = "%m-%d-%Y %H:%M:%S"
 
 # Time in-between queries
 TIME_BETWEEN_QUERIES = 1  # Seconds
-
 
 class ImpalaQueryScheduler(Thread):
     """

--- a/impala_load_test.py
+++ b/impala_load_test.py
@@ -10,7 +10,7 @@ import sys
 import socket
 
 from impala.dbapi import connect
-from impala.rpc import TTransportException
+# from impala.rpc import TTransportException
 import tornado.ioloop
 try:
     import simplejson as json
@@ -66,8 +66,8 @@ class ImpalaQueryScheduler(Thread):
                                      kerberos_service_name=self.__kerberos_service)
                 connection.host = impala_host  # Slap the hostname inside the connection object
                 return connection
-            except TTransportException:
-                raise NameError("Error connecting to Impala daemon [%s]" % impala_host)
+            except Exception as e:
+                raise NameError("[ Error connecting to Impala daemon: %s, exception: %s ]" % (impala_host,e))
 
         return connection_callback
 


### PR DESCRIPTION
There are interface changes between Impyla 0.9.1 and 0.8.0 which require the following patch to work. 

Tested on a CDH5.3 Kerberized cluster. 
